### PR TITLE
Undoing Izo's edit to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 * [Download Caddy](https://caddyserver.com/download) web server and place it into a system path
 * In the project root run
-  * `git clone https://github.com/perch-foundation/feather-extension.git`
+  * `git clone git@github.com:perch-foundation/feather-extension.git`
   * `perch createEnvironment` (creates environment entries)
 * In the project room run
   * `composer install`


### PR DESCRIPTION
It's better to git clone with "git" i.e. ssh urls, rather than https, so you don't get prompted for your password over and over again whenever you want to git pull, or git push, etc. "Cloning with HTTPS URLs (recommended)" is a b.s. recommendation of github overly concerned with security rather than the developer's quality of life, i.e. not having to pass every time you try to run a command.